### PR TITLE
create a CKEDITOR global before defining it

### DIFF
--- a/dev/builder/release/ckeditor/ckeditor.js
+++ b/dev/builder/release/ckeditor/ckeditor.js
@@ -3,6 +3,10 @@
  */
 window.CKEDITOR_BASEPATH = "/ckeditor/";
 
+// Using undefined variables in modules is forbidden so we define CKEDITOR
+// to be null so it's defined before giving it its real value.
+window.CKEDITOR = null;
+
 ﻿/*
 Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.html or http://ckeditor.com/license


### PR DESCRIPTION
This is required by https://phabricator.khanacademy.org/D53481 which adds support for a jest test runner to webapp.